### PR TITLE
Fix “bindings” being absent in dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "getsockethandleaddress",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "repository": "github:clshortfuse/getsockethandleaddress",
   "license": "ISC",
-  "gypfile": true
+  "gypfile": true,
+  "dependencies": {
+    "bindings": "^1.3.0"
+  }
 }


### PR DESCRIPTION
This adds `bindings` to dependencies – `getsockethandleaddress` uses it but doesn’t install it automatically: https://github.com/clshortfuse/node-getsockethandleaddress/blob/950bc9bafa0d7229c2aa779d2e8c3ef57c74f6e9/index.js#L4